### PR TITLE
Hook restana directly into http.createServer()

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Blazing fast, tiny and minimalist *connect-like* web framework for building REST
 
 ![Performance Benchmarks](benchmark-30122019.png)
 > MacBook Pro 2019, 2,4 GHz Intel Core i9, 32 GB 2400 MHz DDR4  
+>
 > - wrk -t8 -c40 -d5s http://127.0.0.1:3000/hi
 
 Read more:  *[restana = faster and efficient Node.js REST APIs](https://itnext.io/restana-faster-and-efficient-node-js-rest-apis-1ee5285ce66)*
@@ -29,7 +30,27 @@ const service = require('restana')({
 })
 ```
 
+Create restana HTTP server with `http.createServer()`:
+
+```js
+const http = require('http')
+const service = require('restana')()
+
+service.get('/hi', (req, res) => {
+  res.send({
+    msg: 'Hello World!'
+  })
+})
+
+http.createServer(service).listen(3000, '0.0.0.0', function () {
+  console.log('running')
+})
+```
+
+Please take note that in the last case, `service.close()` would **not** be available, since restana does **not** have access to http server instance created by `http.createServer`.
+
 > See examples:
+>
 > * [HTTPS service demo](demos/https-service.js)
 > * [HTTP2 service demo](demos/http2-service.js)
 
@@ -301,7 +322,7 @@ const handler = serverless(app);
 module.exports.handler = async (event, context) => {
   return await handler(event, context)
 }
-``` 
+```
 
 > See also:  
 > Running restana service as a lambda using AWS SAM at https://github.com/jkyberneees/restana-serverless
@@ -321,7 +342,7 @@ service.get('/hello', (req, res) => {
 
 // lambda integration
 exports = module.exports = functions.https.onRequest(app.callback());
-``` 
+```
 
 ## Serving static files
 You can read more about serving static files with restana in this link:

--- a/demos/restana-as-http-middleware.js
+++ b/demos/restana-as-http-middleware.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const http = require('http')
+const service = require('./../index')()
+
+service.get('/hi', (req, res) => {
+  res.send({
+    msg: 'Hello World!'
+  })
+})
+
+http.createServer(service).listen(3000, '0.0.0.0', function () {
+  console.log('running')
+})

--- a/index.js
+++ b/index.js
@@ -29,7 +29,16 @@ module.exports = (options = {}) => {
     })
   }
 
-  const service = {
+  const handle = (req, res) => {
+    // request object population
+    res.send = exts.response.send(options, req, res)
+
+    service.getRouter().lookup(req, res)
+  }
+
+  const service = handle
+
+  const service_ = {
     errorHandler: options.errorHandler,
 
     newRouter () {
@@ -44,12 +53,7 @@ module.exports = (options = {}) => {
       return options
     },
 
-    handle: (req, res) => {
-      // request object population
-      res.send = exts.response.send(options, req, res)
-
-      service.getRouter().lookup(req, res)
-    },
+    handle: handle,
 
     start: (...args) => new Promise((resolve, reject) => {
       if (!args || !args.length) args = [3000]
@@ -66,6 +70,8 @@ module.exports = (options = {}) => {
       })
     })
   }
+
+  Object.assign(service, service_)
 
   // apply router capabilities
   requestRouter(options, service)

--- a/specs/hook-in-http-create-server.test.js
+++ b/specs/hook-in-http-create-server.test.js
@@ -1,0 +1,212 @@
+'use strict'
+
+/* global describe, it */
+const request = require('supertest')
+const { createReadStream, readFileSync } = require('fs')
+const path = require('path')
+const stream = require('stream')
+const http = require('http')
+
+describe('All Responses w/ http.createServer()', () => {
+  let server
+  const service = require('../index')()
+
+  service.get('/string', (req, res) => {
+    res.send('Hello World!')
+  })
+
+  service.get('/string-override-status', (req, res) => {
+    res.statusCode = 250
+    res.send('Hello World!')
+  })
+
+  service.get('/html-string', (req, res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8')
+    res.send('<p>Hello World!</p>')
+  })
+
+  service.get('/buffer', (req, res) => {
+    res.send(Buffer.from('Hello World!'))
+  })
+
+  service.get('/buffer-string', (req, res) => {
+    res.setHeader('content-type', 'text/plain; charset=utf-8')
+    res.send(Buffer.from('Hello World!'))
+  })
+
+  service.get('/json', (req, res) => {
+    res.send({ id: 'restana' })
+  })
+
+  service.get('/json-with-content-type', (req, res) => {
+    res.setHeader('content-type', 'application/json')
+    res.send({ id: 'restana' })
+  })
+
+  service.get('/stream', (req, res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8')
+    res.send(createReadStream(path.resolve(__dirname, '../demos/static/src/index.html'), { encoding: 'utf8' }))
+  })
+
+  service.get('/stream-octet', (req, res) => {
+    res.send(
+      stream.Readable.from(
+        (async function * generateTinyStream () {
+          yield 'Hello '
+          yield 'World!'
+        })()
+      )
+    )
+  })
+
+  service.get('/promise', (req, res) => {
+    res.send(Promise.resolve({ hello: 'world' }))
+  })
+
+  service.get('/promise-with-headers', (req, res) => {
+    res.setHeader('content-type', 'application/json')
+    res.setHeader('x-framework', 'restana')
+    res.send(Promise.resolve({ hello: 'world' }))
+  })
+
+  service.get('/promise-rejected', (req, res) => {
+    const error = new Error('Rejected')
+    error.code = 503
+    res.setHeader('content-type', 'text/html')
+    res.send(Promise.reject(error))
+  })
+
+  service.get('/invalid-body', (req, res) => {
+    res.body = true
+    res.setHeader('content-type', 'text/plain; charset=utf-8')
+    res.send()
+  })
+
+  service.get('/error', (req, res) => {
+    const err = new Error('Test')
+    err.code = 501
+    res.send(err)
+  })
+
+  it('should start service', async () => {
+    server = http.createServer(service)
+    server.listen(~~process.env.PORT, '0.0.0.0', ()=>{})
+  })
+
+  it('should GET 200 and string content on /string', async () => {
+    await request(server)
+      .get('/string')
+      .expect(200)
+      .expect('content-type', 'text/plain; charset=utf-8')
+      .expect('Hello World!')
+  })
+
+  it('should GET 250 and string content on /string-override-status', async () => {
+    await request(server)
+      .get('/string-override-status')
+      .expect(250)
+      .expect('content-type', 'text/plain; charset=utf-8')
+      .expect('Hello World!')
+  })
+
+  it('should GET 200 and html content on /html-string', async () => {
+    await request(server)
+      .get('/html-string')
+      .expect(200)
+      .expect('content-type', 'text/html; charset=utf-8')
+      .expect('<p>Hello World!</p>')
+  })
+
+  it('should GET 200 and buffer content on /buffer', async () => {
+    await request(server)
+      .get('/buffer')
+      .expect(200)
+      .expect('content-type', 'application/octet-stream')
+      .expect(Buffer.from('Hello World!'))
+  })
+
+  it('should GET 200 and string content on /buffer-string', async () => {
+    await request(server)
+      .get('/buffer-string')
+      .expect(200)
+      .expect('content-type', 'text/plain; charset=utf-8')
+      .expect('Hello World!')
+  })
+
+  it('should GET 200 and json content on /json', async () => {
+    await request(server)
+      .get('/json')
+      .expect(200)
+      .expect('content-type', 'application/json; charset=utf-8')
+      .expect({ id: 'restana' })
+  })
+
+  it('should GET 200 and json content on /json-with-content-type', async () => {
+    await request(server)
+      .get('/json-with-content-type')
+      .expect(200)
+      .expect('content-type', 'application/json')
+      .expect({ id: 'restana' })
+  })
+
+  it('should GET 200 and html content on /stream', async () => {
+    await request(server)
+      .get('/stream')
+      .expect(200)
+      .expect('content-type', 'text/html; charset=utf-8')
+      .expect(readFileSync(path.resolve(__dirname, '../demos/static/src/index.html'), 'utf8'))
+  })
+
+  it('should GET 200 and buffer content on /stream-octet', async () => {
+    await request(server)
+      .get('/stream-octet')
+      .expect(200)
+      .expect('content-type', 'application/octet-stream')
+  })
+
+  it('should GET 200 and json content on /promise', async () => {
+    await request(server)
+      .get('/promise')
+      .expect(200)
+      .expect({ hello: 'world' })
+      .expect('content-type', 'application/json; charset=utf-8')
+  })
+
+  it('should GET 200 and json content on /promise-with-headers', async () => {
+    await request(server)
+      .get('/promise-with-headers')
+      .expect(200)
+      .expect({ hello: 'world' })
+      .expect('content-type', 'application/json')
+      .expect('x-framework', 'restana')
+  })
+
+  it('should GET 503 and json content on /promise-rejected', async () => {
+    await request(server)
+      .get('/promise-rejected')
+      .expect(503)
+      .expect({ code: 503, message: 'Rejected' })
+      .expect('content-type', 'application/json; charset=utf-8')
+  })
+
+  it('should GET 500 and buffer content on /invalid-body', async () => {
+    await request(server)
+      .get('/invalid-body')
+      .expect(500)
+  })
+
+  it('should GET 501 and json content on /error', async () => {
+    await request(server)
+      .get('/error')
+      .expect(501)
+      .expect('content-type', 'application/json; charset=utf-8')
+      .expect({
+        code: 501,
+        message: 'Test'
+      })
+  })
+
+  it('should successfully terminate the service', async () => {
+    await server.close()
+  })
+})


### PR DESCRIPTION
This PR allows restana to be directly hooked into http native server like this:

```
'use strict'

const http = require('http')
const service = require('restana')()

service.get('/hi', (req, res) => {
  res.send({
    msg: 'Hello World!'
  })
})

http.createServer(service).listen(3000, '0.0.0.0', function () {
  console.log('running')
})
```